### PR TITLE
Fix background-image

### DIFF
--- a/vendor/assets/javascripts/mep-feature-time-rail-thumbnails.js
+++ b/vendor/assets/javascripts/mep-feature-time-rail-thumbnails.js
@@ -52,7 +52,7 @@
       function setThumbnailImage(url) {
         // Make sure the url is protocol/scheme relative
         var protocol_relative_url = url.substr(url.indexOf('://')+1);
-        $('.mejs-plugin-time-float-thumbnail').css('background-image','url(' + protocol_relative_url.split('#')[0] + ')');
+        $('.mejs-plugin-time-float-thumbnail').css('background-image','url("' + protocol_relative_url.split('#')[0] + '")');
       }
 
       var


### PR DESCRIPTION
The background-image CSS property didn't get set when the sprite was in a subdirectory, quoting the URL fixes this.
